### PR TITLE
Make setup.py usable in environments without requests installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,21 @@
 # Copyright (C) 2013 Julian Metzler
 # See the LICENSE file for the full license.
 
-from tweetpony import metadata
 from setuptools import setup, find_packages
 
+metadata = {}
+with open('tweetpony/metadata.py') as f:
+  exec(f, metadata)
+
 setup(
-	name = metadata.name,
-	version = metadata.version,
-	description = metadata.description,
-	license = metadata.license,
-	author = metadata.author,
-	author_email = metadata.author_email,
-	install_requires = metadata.dependencies,
-	url = metadata.url,
-	keywords = metadata.keywords,
+	name = metadata['name'],
+	version = metadata['version'],
+	description = metadata['description'],
+	license = metadata['license'],
+	author = metadata['author'],
+	author_email = metadata['author_email'],
+	install_requires = metadata['dependencies'],
+	url = metadata['url'],
+	keywords = metadata['keywords'],
 	packages = find_packages(),
 )

--- a/tweetpony/__init__.py
+++ b/tweetpony/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2013 Julian Metzler
 # See the LICENSE file for the full license.
 
-from tweetpony.api import *
-from tweetpony.api import *
+from .api import *


### PR DESCRIPTION
setup.py should never rely on executing a module (including importing from it); this potentially introduces a bootstrapping problem, as is the case here with "requests". Build systems trying to build your package need to act on the install_requires parameter in the setup() function, in order to pull in dependencies, but this can never be reached.

(Reference - http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package?answertab=votes#tab-top )
